### PR TITLE
Rewrite parser using builder pattern

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ serde = { version = "1", optional = true, features = ["derive"] }
 [dev-dependencies]
 env_logger = "0.6"
 serde_json = "1"
+indoc = "0.3"

--- a/examples/parse_file.rs
+++ b/examples/parse_file.rs
@@ -26,8 +26,9 @@ fn main() -> std::io::Result<()> {
     let mut reader = BufReader::new(file);
 
     // Process airspaces
+    let airspaces = parse(&mut reader).unwrap_or_else(|e| fail!(e));
     println!("Airspaces:");
-    while let Some(airspace) = parse(&mut reader).unwrap_or_else(|e| fail!(e)) {
+    for airspace in airspaces {
         println!("- {}", airspace);
     }
     println!("Done.");


### PR DESCRIPTION
The other approach was flawed, since the order of fields is not guaranteed. Additionally, the support for variables in the OpenAir format means we need some way to keep state. Using the builder pattern
is a better fit in this case.

This is a breaking API change.